### PR TITLE
feat: re-add GID_FILES and UID_FILES

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ USE_RC_SUBR=   	${PORTNAME}-collector ${PORTNAME}-dogstatsd
 RUNDIR?=	/var/run/${PORTNAME}
 LOGDIR?=	/var/log/${PORTNAME}
 
+GID_FILES=	${PATCHDIR}/GIDs
+UID_FILES=	${PATCHDIR}/UIDs
+
 USERS=		datadog
 GROUPS=		${USERS}
 


### PR DESCRIPTION
They were lost in https://github.com/neighbourhoodie/dd-agent-FreeBSD/commit/1247aef294456ca4dc3099385809c9ca14fc038e?diff=unified#diff-b67911656ef5d18c4ae36cb6741b7965L43
